### PR TITLE
playRTTTLString: not all paths do return properly

### DIFF
--- a/src/PeripheryManager.cpp
+++ b/src/PeripheryManager.cpp
@@ -319,6 +319,7 @@ const char *PeripheryManager_::playRTTTLString(String rtttl)
         melodyName[sizeof(melodyName) - 1] = '\0';
         return melodyName;
     }
+    return nullptr; // RTTTL not supported with DFPlayer
 }
 
 const char *PeripheryManager_::playFromFile(String file)


### PR DESCRIPTION
playRTTTLString did not have a valid return path if DFPLAYER is ACTIVE (fixed compiler warning)