### PR TITLE
Fix previously active pixels when switching to frost effect

### DIFF
--- a/src/effects.cpp
+++ b/src/effects.cpp
@@ -1291,10 +1291,13 @@ void EffectOverlay(FastLED_NeoMatrix *matrix, int16_t x, int16_t y, OverlayEffec
                     // Turn off the pixel after MAX_COLOR_CHANGES changes
                     if (colorChanges[i][j] > 6)
                     {
-                        leds[i][j] = CRGB::Black;
                         colorChanges[i][j] = 0; // Reset the counter for this pixel
                     }
                 }
+                if (colorChanges[i][j] == 0)
+                {
+                    leds[i][j] = CRGB::Black;
+                }            
             }
         }
 


### PR DESCRIPTION
The pixels that were drawn in a previous effect are initially still visible when the frost effect is being activated.  This change fixes that problem by clearing those pixels by setting all pixels to black (not drawn) when it is not part of the frost effect.