### PR TITLE
Show the status of dev.json in the stats

### DIFF
--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -1666,6 +1666,7 @@ String DisplayManager_::getStats()
   doc[F("uid")] = uniqueID;
   doc[F("matrix")] = !MATRIX_OFF;
   doc[IpAddrKey] = WiFi.localIP();
+  doc[F("dev_json")] = DEV_JSON;
   String jsonString;
   serializeJson(doc, jsonString);
   return jsonString;

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -60,8 +60,10 @@ void loadDevSettings()
         {
             if (DEBUG_MODE)
                 DEBUG_PRINTLN(F("Failed to read dev settings"));
+            DEV_JSON = "error";
             return;
         }
+        DEV_JSON = "ok";
 
         if (DEBUG_MODE)
             DEBUG_PRINTF("%i dev settings found", doc.size());
@@ -234,6 +236,7 @@ void loadDevSettings()
     }
     else
     {
+        DEV_JSON = "missing";
         if (DEBUG_MODE)
             DEBUG_PRINTLN("Devsettings not found");
     }
@@ -463,3 +466,4 @@ int WEB_PORT = 80;
 OverlayEffect GLOBAL_OVERLAY = NONE;
 String HOSTNAME = "";
 bool BUZ_VOL = false;
+String DEV_JSON = "";

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -150,4 +150,5 @@ extern OverlayEffect GLOBAL_OVERLAY;
 extern String HOSTNAME;
 extern int WEB_PORT;
 extern bool BUZ_VOL;
+extern String DEV_JSON;
 #endif // Globals_H


### PR DESCRIPTION
This adresses a little problem that bites me every now and then. (Don't ask :))

It adds the status of dev.json ("missing", "error", "ok") to the stats.