### PR TITLE
Fix for duplicate entries appearing

### DIFF
--- a/lib/webserver/esp-fs-webserver.h
+++ b/lib/webserver/esp-fs-webserver.h
@@ -195,10 +195,10 @@ public:
         if (hidden)
             key += "-hidden";
 
-        // Univoque key name
+        // Unique key name
         if (key.equals("param-box"))
         {
-            key += numOptions;
+            key = key + "-" + val;
         }
         if (key.equals("raw-javascript"))
         {


### PR DESCRIPTION
Utilize the value to distinguish parameter boxes, rather than relying on the position of box within the options.
This resolves the issue of duplicate entries appearing.

Solves #654, #623, #549 and probably more.

You have to edit "DoNotTouch.json" once and remove duplicate entries.